### PR TITLE
[MRG] copy dimensions from non-typecast variable config-space if available

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -301,9 +301,8 @@ class Optimizer(object):
         random_state : int, RandomState instance, or None (default)
             Set the random state of the copy.
         """
-
         optimizer = Optimizer(
-            dimensions=self.space.dimensions,
+            dimensions=self.space.config_space if self.space.config_space != None else self.space.dimensions,
             base_estimator=self.base_estimator_,
             n_initial_points=self.n_initial_points_,
             initial_point_generator=self._initial_point_generator,


### PR DESCRIPTION
- `space.dimension` is typecast to a `Dimension` object.
- This means that the copied `Optimizer` would behave differently since its dimensions are no longer treated as a `ConfigurationSpace`.
- This change uses the saved, original `config_space` variable to achieve consistent behavior. 
- If `config_space` is not available, just use the `dimensions` as previously done.